### PR TITLE
passing isMobile to the renderCell function

### DIFF
--- a/src/calendar/MonthCalendar.tsx
+++ b/src/calendar/MonthCalendar.tsx
@@ -15,16 +15,18 @@ interface IDayViewProps {
   renderCell?: RenderCellFn;
   isPreviousPeriod?: boolean;
   isNextPeriod?: boolean;
+  isMobile?: boolean;
 }
 export const DayView: React.FC<IDayViewProps> = ({
   date,
   renderCell = defaultCellRenderer,
   isPreviousPeriod = false,
   isNextPeriod = false,
+  isMobile = false
 }) => {
   return (
     <div style={{ width: "calc(100% / 7)" }}>
-      {renderCell({ date, isPreviousPeriod, isNextPeriod })}
+      {renderCell({ date, isPreviousPeriod, isNextPeriod, isMobile})}
     </div>
   );
 };

--- a/src/calendar/RenderCell.tsx
+++ b/src/calendar/RenderCell.tsx
@@ -4,6 +4,7 @@ interface IRenderCellProps {
   date: Date
   isPreviousPeriod: boolean
   isNextPeriod: boolean
+  isMobile: boolean
 }
 export type RenderCellFn = (props: IRenderCellProps) => React.ReactNode
 

--- a/src/calendar/WeekCalendar.tsx
+++ b/src/calendar/WeekCalendar.tsx
@@ -9,11 +9,12 @@ interface IDayViewProps {
   renderCell?: RenderCellFn
   isPreviousPeriod?: boolean
   isNextPeriod?: boolean
+  isMobile?: boolean
 }
-export const DayView: React.FC<IDayViewProps> = ({ date, renderCell = defaultCellRenderer, isPreviousPeriod = false, isNextPeriod = false }) => {
+export const DayView: React.FC<IDayViewProps> = ({ date, renderCell = defaultCellRenderer, isPreviousPeriod = false, isNextPeriod = false, isMobile = true }) => {
   return (
     <div style={{ width: '100%' }}>
-      {renderCell({ date, isPreviousPeriod, isNextPeriod })}
+      {renderCell({ date, isPreviousPeriod, isNextPeriod, isMobile })}
     </div>
   )
 }

--- a/stories/api.stories.tsx
+++ b/stories/api.stories.tsx
@@ -34,7 +34,7 @@ export const CustomStyles = () => {
       </div>
     )
   }, [])
-  const renderCell = React.useCallback(({ date }) => {
+  const renderCell = React.useCallback(({ date, isPrevious, isNext, isMobile }) => {
     const today = isToday(date)
     return (
       <div className={`calendar-cell ${today ? 'today' : ''}`}>
@@ -45,7 +45,7 @@ export const CustomStyles = () => {
         </div>
         <div className="cell-right">
           <div className="date">
-            {format(date, 'dd')}
+            {isMobile ? format(date, 'dd') + " " + format(date, 'E') : format(date, 'dd')}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Sometimes you would like to have your calendar cells rendered differently for PC and for mobile devices. To find out what is the current view state we can use isMobile variable. It has been added to the interface of renderCell function.